### PR TITLE
[WF-316] Fix access of private variable in charm lib

### DIFF
--- a/lib/charms/git_integrator/v0/git.py
+++ b/lib/charms/git_integrator/v0/git.py
@@ -122,7 +122,7 @@ SSHPrivateKeyStr = typing.Annotated[
 class GitProviderModel(data_interfaces.BaseCommonModel):
     """Provider side of the git relation interface."""
 
-    repository_url: str | None = None
+    repository_url: str
     path: str | None = pydantic.Field(default=None, tag="resettable")
     tracking_ref: str | None = pydantic.Field(default=None, tag="resettable")
 

--- a/lib/charms/git_integrator/v0/git.py
+++ b/lib/charms/git_integrator/v0/git.py
@@ -92,7 +92,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -480,7 +480,7 @@ class GitRequires(ops.Object):
     @property
     def relations(self) -> list[ops.Relation]:
         """Relations for the git interface."""
-        return list(self._charm.model.relations.get(self.relation_name, []))
+        return list(self._charm.model.relations.get(self._relation_name, []))
 
     def is_ready(self, relation: typing.Optional[ops.Relation] = None) -> bool:
         """Readiness of a relation's git connection information."""


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
A method in the charm lib accessed a private variable without the `_`. Fix typo

Additionally, make `repository_url` required in `GitProviderModel` (as a git connection information that lacks this does not make sense)

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
